### PR TITLE
Fix: Add viewBox to departamentos_uruguay.svg to ensure full map visi…

### DIFF
--- a/departamentos_uruguay.svg
+++ b/departamentos_uruguay.svg
@@ -6,6 +6,7 @@
    width="903.70679"
    height="1004.3277"
    id="svg2925"
+   viewBox="0 0 903.70679 1004.3277"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    sodipodi:docname="departamentos_uruguay.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"


### PR DESCRIPTION
…bility

- Added the viewBox attribute to the root <svg> element in departamentos_uruguay.svg.
- The viewBox is set to "0 0 903.70679 1004.3277" to match the SVG's width and height attributes.
- This change allows the SVG to scale correctly and be fully visible when embedded in index.html via the <object> tag, resolving the issue where only the top-left quadrant was displayed.